### PR TITLE
Fix URL parsing

### DIFF
--- a/lib/prophet/prophet.rb
+++ b/lib/prophet/prophet.rb
@@ -127,10 +127,11 @@ class Prophet
     github.login
     @log.info "Successfully logged into GitHub (API v#{github.api_version}) with user '#{user}'."
     # Ensure the user has access to desired project.
-    # NOTE: Both variants should work:
+    # NOTE: All three variants should work:
     # 'ssh://git@github.com:user/project.git'
     # 'git@github.com:user/project.git'
-    @project ||= /com:(.*)\.git/.match(git_config['remote.origin.url'])[1]
+    # 'https://github.com/user/project.git'
+    @project ||= /github\.com[\/:](.*)\.git$/.match(git_config['remote.origin.url'])[1]
     begin
       github.repo @project
       @log.info "Successfully accessed GitHub project '#{@project}'"

--- a/spec/prophet.spec
+++ b/spec/prophet.spec
@@ -424,4 +424,14 @@ describe Prophet do
     @prophet.run
   end
 
+  it 'should read https URLs from .git/config' do
+    @prophet.stub(:git_config).and_return(
+      'github.login' => 'default_login',
+      'github.password' => 'default_password',
+      'remote.origin.url' => 'https://github.com/user/project.git'
+    )
+    @github.should_receive(:pulls).with(@project, 'open').and_return([])
+    @prophet.run
+  end
+
 end


### PR DESCRIPTION
Extend the connect_to_github URL regex to also parse https URLs.
