### PR TITLE
Ignore Ruby 1.8.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.1.1
   - 2.1.2
-  - jruby-18mode
   - jruby-19mode
   - jruby-head
   - rbx-2.2.3
@@ -16,7 +14,7 @@ matrix:
     - rvm: rbx-2.2.3
 before_install:
   - gem install bundler
-  # Unfortunately, these old versions of octokit, faraday, faraday_middleware 
+  # Unfortunately, these old versions of octokit, faraday, faraday_middleware
   # are not found by bundler automatically. Hence a manual installation.
   - gem install faraday_middleware --version 0.9.0
   - gem install faraday --version 0.8.8


### PR DESCRIPTION
Let's fix test runs on TravisCI by just ignoring Ruby 1.8.x.
The real problem is that the old version of Octokit isn't found, but I also don't care about obsolete Ruby versions anymore.