### PR TITLE
Skip prophet for pull requests originating from forked repositories

### DIFF
--- a/lib/prophet/prophet.rb
+++ b/lib/prophet/prophet.rb
@@ -227,6 +227,7 @@ class Prophet
       end
     end
 
+    logger.info "Pull request comes from a fork." if @request.from_fork
     logger.info "Not running for request ##{@request.id}."
     false
   end

--- a/lib/prophet/pull_request.rb
+++ b/lib/prophet/pull_request.rb
@@ -4,12 +4,14 @@ class PullRequest
                 :content,
                 :comment,
                 :head_sha,
-                :target_head_sha
+                :target_head_sha,
+                :from_fork
 
   def initialize(content)
     @content = content
     @id = content.number
     @head_sha = content.head.sha
+    @from_fork = content.head.repo.fork
   end
 
 end

--- a/spec/prophet_spec.rb
+++ b/spec/prophet_spec.rb
@@ -15,6 +15,7 @@ describe Prophet do
     @api_response = double 'api response'
     @api_response.stub(:number).and_return(request_id)
     @api_response.stub_chain(:head, :sha).and_return('pull_head_sha')
+    @api_response.stub_chain(:head, :repo, :fork).and_return(false)
     @project = 'user/project'
     prophet.prepare_block = lambda { }
     prophet.exec_block = lambda { }

--- a/spec/prophet_spec.rb
+++ b/spec/prophet_spec.rb
@@ -43,6 +43,7 @@ describe Prophet do
 
   it 'checks existing status to determine whether a new run is necessary' do
     prophet.should_receive(:pull_requests).and_return([request])
+    request.should_receive(:from_fork).and_return(false)
     @api_response.should_receive :title
     @api_response.should_receive(:mergeable).and_return(true)
     # See if we're actually querying for issue comments.
@@ -523,4 +524,18 @@ describe Prophet do
     end
   end
 
+  describe '#run_necessary?' do
+    subject { prophet.send :run_necessary? }
+
+    before do
+      prophet.instance_variable_set :@request, request
+      allow(@api_response).to receive(:title)
+    end
+
+    context 'request comes from a fork' do
+      before { request.from_fork = true }
+
+      it { is_expected.to eq false }
+    end
+  end
 end


### PR DESCRIPTION
Allowing prophet to run for arbitrary pull requests opened up some serious holes for malicious code execution on CI machines. 
By querying an attribute coming with the Github API response we can simply skip these pull requests automatically and have a closer look at contributions coming from outside the repository.